### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,30 +7,30 @@
 #######################################
 
 ButtonEvents	KEYWORD1
-ButtonState		KEYWORD1
-ButtonEvent		KEYWORD1
+ButtonState	KEYWORD1
+ButtonEvent	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-attach			KEYWORD2
-activeHigh		KEYWORD2
-activeLow		KEYWORD2
+attach	KEYWORD2
+activeHigh	KEYWORD2
+activeLow	KEYWORD2
 debounceTime	KEYWORD2
 doubleTapTime	KEYWORD2
-holdTime		KEYWORD2
-interval		KEYWORD2
-update			KEYWORD2
-reset			KEYWORD2
-retime			KEYWORD2
-event			KEYWORD2
-tapped			KEYWORD2
+holdTime	KEYWORD2
+interval	KEYWORD2
+update	KEYWORD2
+reset	KEYWORD2
+retime	KEYWORD2
+event	KEYWORD2
+tapped	KEYWORD2
 doubleTapped	KEYWORD2
-held			KEYWORD2
-read			KEYWORD2
-rose			KEYWORD2
-fell			KEYWORD2
+held	KEYWORD2
+read	KEYWORD2
+rose	KEYWORD2
+fell	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -40,10 +40,10 @@ fell			KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-idle			LITERAL1
-pressed			LITERAL1
-released		LITERAL1
-none			LITERAL1
-tap				LITERAL1
-doubleTap		LITERAL1
-hold			LITERAL1
+idle	LITERAL1
+pressed	LITERAL1
+released	LITERAL1
+none	LITERAL1
+tap	LITERAL1
+doubleTap	LITERAL1
+hold	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords